### PR TITLE
NotifyHandler

### DIFF
--- a/handlers/notifyhandler.go
+++ b/handlers/notifyhandler.go
@@ -116,13 +116,17 @@ func read(receiver string) (*string) {
 	}
 
 	buff, err := ioutil.ReadFile(file)
-	check(err)
+	if err != nil {
+		return nil
+	}
 
 	var notices []Notice
 	json.Unmarshal(buff, &notices)
 
 	err = os.Remove(file)
-	check(err)
+	if err != nil {
+		return nil
+	}
 
 	results := ""
 	for _, notice := range notices {

--- a/handlers/notifyhandler.go
+++ b/handlers/notifyhandler.go
@@ -34,7 +34,7 @@ func (h *NotifyHandler) HandleIncoming(r *gobot.Room, p *proto.Packet) (*proto.P
 	}
 
 	results := read(payload.Sender.Name)
-	if *results != "" {
+	if results != nil {
 		if _, err := r.SendText(&payload.ID, *results); err != nil {
 			return nil, err
 		}

--- a/handlers/notifyhandler.go
+++ b/handlers/notifyhandler.go
@@ -121,8 +121,8 @@ func read(receiver string) (*string) {
 	var notices []Notice
 	json.Unmarshal(buff, &notices)
 
-//	err = os.Remove(file)
-//	check(err)
+	err = os.Remove(file)
+	check(err)
 
 	results := ""
 	for _, notice := range notices {

--- a/handlers/notifyhandler.go
+++ b/handlers/notifyhandler.go
@@ -52,6 +52,10 @@ func (h *NotifyHandler) HandleIncoming(r *gobot.Room, p *proto.Packet) (*proto.P
 	}
 	go notice.write()
 
+	if _, err := r.SendText(&payload.ID, "/me noted your message and will inform " + data[1] + " about it."); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 

--- a/handlers/notifyhandler.go
+++ b/handlers/notifyhandler.go
@@ -1,0 +1,139 @@
+// Package handlers provides several pre-baked gobot.Handlers for convenience.
+package handlers
+
+import (
+	"os"
+	"io/ioutil"
+	"strings"
+
+	"euphoria.io/heim/proto"
+	"github.com/cpalone/gobot"
+	"github.com/dustin/go-humanize"
+	"encoding/json"
+)
+
+// NotifyHandler responds to a send-event starting with "!tell"
+type NotifyHandler struct{}
+
+// HandleIncoming satisfies the Handler interface.
+func (h *NotifyHandler) HandleIncoming(r *gobot.Room, p *proto.Packet) (*proto.Packet, error) {
+	r.Logger.Debugln("Checking for tell command...")
+
+	if p.Type != proto.SendEventType {
+		return nil, nil
+	}
+	raw, err := p.Payload()
+	if err != nil {
+		return nil, err
+	}
+	payload, ok := raw.(*proto.SendEvent)
+
+	if !ok {
+		r.Logger.Warningln("Unable to assert packet as SendEvent.")
+		return nil, err
+	}
+
+	results := read(payload.Sender.Name)
+	if *results != "" {
+		if _, err := r.SendText(&payload.ID, *results); err != nil {
+			return nil, err
+		}
+	}
+
+	if !strings.HasPrefix(payload.Content, "!tell @") {
+		return nil, nil
+	}
+	data := strings.SplitN(payload.Content, " ", 3)
+	notice := Notice{
+		Time: payload.UnixTime,
+		Sender: payload.Sender.Name,
+		Receiver: strings.Replace(data[1], "@", "", 1),
+		Message: data[2],
+	}
+	go notice.write()
+
+	return nil, nil
+}
+
+// Run is a no-op- the SampleHandler does not need to run continuously, only in
+// response to an incoming packet.
+func (h *NotifyHandler) Run(r *gobot.Room) {
+	return
+}
+
+// Stop is also a no-op- there is nothing to stop.
+func (h *NotifyHandler) Stop(r *gobot.Room) {
+	return
+}
+
+const notice_directory = "notices/"
+
+type Notice struct{
+	Message		string 	`json:"message"`
+	Sender 		string	`json:"sender"`
+	Receiver 	string	`json:"receiver"`
+	Time	proto.Time	`json:"timestamp"`
+}
+
+func (n *Notice) display() (*string) {
+	timeago := humanize.Time(n.Time.StdTime())
+	formatted := "[" + timeago + "] @" + n.Sender + " said: " + n.Message + "\n"
+	return &formatted
+}
+
+func (notice *Notice) write() {
+	if _, err := os.Stat(notice_directory); os.IsNotExist(err) {
+		err = os.MkdirAll(notice_directory, 0711)
+		check(err)
+	}
+
+	f, err := os.OpenFile(notice_directory + notice.Receiver, os.O_WRONLY | os.O_CREATE, 0644);
+	check(err)
+	defer f.Close()
+
+	fs, err := f.Stat()
+	check(err)
+
+	bytes, _ := json.Marshal(&notice)
+	if fs.Size() == 0 {
+		f.WriteString("[")
+		f.Write(bytes)
+		f.WriteString("]")
+	} else {
+		f.Seek(-1, os.SEEK_END)
+		f.WriteString(",")
+		f.Write(bytes)
+		f.WriteString("]")
+	}
+
+	f.Sync()
+}
+
+func read(receiver string) (*string) {
+	file := notice_directory + receiver
+	if _, err := os.Stat(file); os.IsNotExist(err) {
+		return nil
+	}
+
+	buff, err := ioutil.ReadFile(file)
+	check(err)
+
+	var notices []Notice
+	json.Unmarshal(buff, &notices)
+
+//	err = os.Remove(file)
+//	check(err)
+
+	results := ""
+	for _, notice := range notices {
+		results += *notice.display()
+	}
+
+	return &results
+}
+
+func check(e error) {
+	if e != nil {
+		panic(e)
+	}
+}

--- a/sample/main.go
+++ b/sample/main.go
@@ -12,7 +12,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	b.Rooms["test"].Handlers = []gobot.Handler{&handlers.PongHandler{}}
+
+//	b.Rooms["test"].Handlers = append(b.Rooms["test"].Handlers, &handlers.PongHandler{})
 	b.Rooms["testing"].Handlers = []gobot.Handler{&handlers.PongHandler{}}
 	b.RunAllRooms()
 }


### PR DESCRIPTION
To use, just type !tell @username message. 

An extensible notice struct is used. Its marshalled into a JSON format and it will be logged into a file in a new directory under gobots/sample/notices/username. So the msgs won't be lost even if the bot crashes for some other reason. The messages are purged when it is sent to the receipient. It also handles multi-line messages.

When the user comes online and types something, the response will be something like this. 
[26 minutes ago] @nutty said: message 1
[26 minutes ago] @nutty said: message 2
[25 minutes ago] @nutty said: Something to say 

Things to do:
1. Need to do some channel handling when reading from file (still learning this). But should be okay for lightweight use. File writing uses a goroutine. 
2. Might need a help message, etc. 

Limitations: Does not handle usernames with spaces like "super duper cat:". Can't recognize whether the message is !tell @super or !tell @super duper or !tell @super duper cat.
